### PR TITLE
Added a JSON Output Option

### DIFF
--- a/subbrute.py
+++ b/subbrute.py
@@ -423,10 +423,16 @@ def print_target(target, record_type = None, subdomains = "names.txt", resolve_l
                 json_output.write(json_result.strip())
                 json_output.flush()
             else:
-                json_result = json.dumps({"hostname" : hostname, "ipv4" : ",".join(response).strip(",")}) + ","
+                json_result = json.dumps({"hostname" : hostname, "record_type" : ",".join(response).strip(",")}) + ","
                 json_output.write(json_result.strip())
                 json_output.flush()
-
+    #The below formats the JSON to be semantically correct, after the scan has been completed
+    if json_output:
+        json_data = open(options.json, "r").read()
+        #Remove trailing comma, format json and rewrite json file with formatted json
+        formatted_json = "[" + json_data.strip(",") + "]"
+        json_output = open(options.json, "w")
+        json_output.write(formatted_json)
 
 def run(target, record_type = None, subdomains = "names.txt", resolve_list = "resolvers.txt", process_count = 16):
     subdomains = check_open(subdomains)
@@ -624,9 +630,3 @@ if __name__ == "__main__":
         target = target.strip()
         if target:
             print_target(target, record_type, options.subs, options.resolvers, options.process_count, output, json_output)
-    if json_output:
-        json_data = open(options.json, "r").read()
-        #Remove trailing comma, format json and rewrite json file with formatted json
-        formatted_json = "[" + json_data.strip(",") + "]"
-        json_output = open(options.json, "w")
-        json_output.write(formatted_json)

--- a/subbrute.py
+++ b/subbrute.py
@@ -17,6 +17,7 @@ import random
 import ctypes
 import dns.resolver
 import dns.rdatatype
+import json
 
 #Python 2.x and 3.x compatiablity
 #We need the Queue library for exception handling
@@ -403,7 +404,7 @@ def extract_subdomains(file_name):
     subs_sorted = sorted(subs.keys(), key = lambda x: subs[x], reverse = True)
     return subs_sorted
 
-def print_target(target, record_type = None, subdomains = "names.txt", resolve_list = "resolvers.txt", process_count = 16, output = False):
+def print_target(target, record_type = None, subdomains = "names.txt", resolve_list = "resolvers.txt", process_count = 16, output = False, json_output = False):
     for result in run(target, record_type, subdomains, resolve_list, process_count):
         (hostname, record_type, response) = result
         if not record_type:
@@ -415,6 +416,17 @@ def print_target(target, record_type = None, subdomains = "names.txt", resolve_l
         if output:
             output.write(result + "\n")
             output.flush()
+        if json_output:
+            #If the user requests the A record in the output
+            if not record_type:
+                json_result = json.dumps({"hostname" : hostname}) + ","
+                json_output.write(json_result.strip())
+                json_output.flush()
+            else:
+                json_result = json.dumps({"hostname" : hostname, "ipv4" : ",".join(response).strip(",")}) + ","
+                json_output.write(json_result.strip())
+                json_output.flush()
+
 
 def run(target, record_type = None, subdomains = "names.txt", resolve_list = "resolvers.txt", process_count = 16):
     subdomains = check_open(subdomains)
@@ -556,7 +568,8 @@ if __name__ == "__main__":
               type = "string", help = "(optional) A list of DNS resolvers, if this list is empty it will OS's internal resolver default = 'resolvers.txt'")
     parser.add_option("-t", "--targets_file", dest = "targets", default = "",
               type = "string", help = "(optional) A file containing a newline delimited list of domains to brute force.")
-    parser.add_option("-o", "--output", dest = "output",  default = False, help = "(optional) Output to file")
+    parser.add_option("-o", "--output", dest = "output",  default = False, help = "(optional) Output to file (Greppable Format)")
+    parser.add_option("-j", "--json", dest="json", default = False, help="(optional) Output to file (JSON Format)")
     parser.add_option("-a", "-A", action = 'store_true', dest = "ipv4", default = False,
               help = "(optional) Print all IPv4 addresses for sub domains (default = off).")
     parser.add_option("--type", dest = "type", default = False,
@@ -591,7 +604,14 @@ if __name__ == "__main__":
         try:
              output = open(options.output, "w")
         except:
-            error("Faild writing to file:", options.output)
+            error("Failed writing to file:", options.output)
+
+    json_output = False
+    if options.json:
+        try:
+            json_output = open(options.json, "w")
+        except:
+            error("Failed writing to file:", options.json)
 
     record_type = False
     if options.ipv4:
@@ -603,4 +623,10 @@ if __name__ == "__main__":
     for target in targets:
         target = target.strip()
         if target:
-            print_target(target, record_type, options.subs, options.resolvers, options.process_count, output)
+            print_target(target, record_type, options.subs, options.resolvers, options.process_count, output, json_output)
+    if json_output:
+        json_data = open(options.json, "r").read()
+        #Remove trailing comma, format json and rewrite json file with formatted json
+        formatted_json = "[" + json_data.strip(",") + "]"
+        json_output = open(options.json, "w")
+        json_output.write(formatted_json)


### PR DESCRIPTION
This commit adds a command line argument (-j or --json). It allows users to output the results of Subbrute to a JSON object. JSON objects produced by the -j / --json argument will look like the following:

Command: `./subbrute.py google.com -j test.json`
Output: `[{"hostname": "google.com"}, {"hostname": "www.google.com"}]`

Due to the way Subbrute writes results concurrently as it finds them, I was unable to come up with a good solution to append perfectly formatted JSON objects to a file in real time without causing a lot of memory usage (I/O intensive). 

What I did instead was, write out JSON objects in the file, in real time, except with a few minor formatting faults (missing "[" and "]" (array) wrapping) and could not remove the trailing comma. These minor formatting faults are completely solved *after* Subbrute finishes running. If you can come up with a better solution, that'd be awesome, but this is the best I've got atm...

It also supports the `-a` command, output would look like:

`[{"hostname": "google.com", "ipv4": "216.58.210.14"},{"hostname": "www.google.com", "ipv4": "173.194.112.80,173.194.112.81,173.194.112.84,173.194.112.82,173.194.112.83"}]`

As a small sample of how one could access these JSON objects:

```
import json
json_file = open("subdomains.json", "r")
json_data = json.loads(json_file)
for i in json_data:
    print i['hostname']
```
This would return:
```
google.com
www.google.com
..etc
```