### PR TITLE
Added setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ subdomain-bruteforcer (SubBrute)
 =====================
 SubBrute is a community driven project with the goal of creating the fastest, and most accurate subdomain enumeration tool.  Some of the magic behind SubBrute is that it uses open resolvers as a kind of proxy to circumvent DNS rate-limiting (https://www.us-cert.gov/ncas/alerts/TA13-088A).  This design also provides a layer of anonymity, as SubBrute does not send traffic directly to the target's name servers.
 
+Installation
+============
+
+To install, just clone this repository with `git clone https://github.com/TheRook/subbrute.git` and then install with `cd subbrute && python setup.py install`.
+
+SubBrute can then be called with `subbrute` (or `subbrute.exe` under Windows. Note that under Windows, the python 'Scripts' folder must be in the PATH). SubBrute can also be called without installation by running `python subbrute.py` from the project folder. For details, see [More Information](https://github.com/TheRook/subbrute#more-information)
+
 Whats new in v2.0?
 =====================
 A lot of exciting updates... except for the readme file,  which still needs to be updated.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import os
+from setuptools import setup, find_packages
+
+
+long_description = open(
+    os.path.join(
+        os.path.dirname(__file__),
+        'README.md'
+    )
+).read()
+
+
+setup(
+    name='SubBrute',
+    version='2.0',
+    license='LICENSE',
+    url='https://github.com/TheRook/subbrute',
+    description='A fast and accurate subdomain enumeration tool.',
+    long_description=long_description,
+    packages=find_packages('.', exclude=["dnslib", "*.tests", "*.tests.*", "tests.*", "tests"]),
+    py_modules=["subbrute"],
+    data_files=[('', ['names.txt', 'resolvers.txt', 'names_small.txt'])],
+    install_requires=['dnslib'],
+    entry_points={
+        'console_scripts': [
+            'subbrute = subbrute:main',
+        ]
+    },
+    keywords=['dns', 'subdomain', 'spider']
+)

--- a/subbrute.py
+++ b/subbrute.py
@@ -794,7 +794,8 @@ def signal_init():
         #Windows
         pass
 
-if __name__ == "__main__":
+
+def main():
     if getattr(sys, 'frozen', False):
         # cx_freeze windows:
         base_path = os.path.dirname(sys.executable)
@@ -857,3 +858,6 @@ if __name__ == "__main__":
         if target:
             trace(target, record_type, options.subs, options.resolvers, options.process_count, options.print_data, output, json_output)
             print_target(target, record_type, options.subs, options.resolvers, options.process_count, options.print_data, output, json_output)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds the conventional `setup.py` file to make installation a bit easier. I believe this is entirely backwards compatible, so you can still run subbrute directly from the project folder, if desired. However, users can now install `subbrute` globally with `sudo python setup.py install` or (without root) `python setup.py install --user`.

The wrapper being executed is automatically generated via the entry_points feature of setuptools (this also generates an exe on windows). I added a short section to the README about installation with this script.

Currently, the script is configured to pull the latest dnslib, unless you are running from the project folder (in which case the one in the repo is used). I'm not sure I love this, but it does maintain exactly the existing behavior.

Ultimately, this is a step towards what I think would be the best installation setup: uploading to pypi. Then people can just `pip install subbrute` and never touch github. This will only get better in the future, as pip is shipped with current python (3.4+).
