### PR TITLE
Add explicit break when resolver pool is small

### DIFF
--- a/subbrute.py
+++ b/subbrute.py
@@ -24,6 +24,9 @@ import datetime
 import socket
 import struct
 
+# Minimum number of seconds to wait before querying the same nameserver again
+REPEAT_TIMEOUT = 5
+
 #Python 2.x and 3.x compatiablity
 #We need the Queue library for exception handling
 try:
@@ -57,6 +60,9 @@ class resolver:
         response = None
         if name_server == False:
             name_server = self.get_ns()
+            # If we just picked the same one again, give it a break
+            if self.last_resolver == name_server:
+                time.sleep(REPEAT_TIMEOUT)
         else:
             self.wildcards = {}
             self.failed_code = None


### PR DESCRIPTION
There is a period during the bootstrapping process (when there are still very few verified servers in `resolver_q`) and possibly near the end (when the list is exhausted) when a resolver might only have one nameserver. In this case, it will hammer that same resolver query after query with no break. This change puts in an explicit wait for these transient times in order to keep to the implicit contract of not querying the same server more than about once every 5 seconds. 