### PR TITLE
Add timeout to DNS queries

### DIFF
--- a/subbrute.py
+++ b/subbrute.py
@@ -24,6 +24,9 @@ import datetime
 import socket
 import struct
 
+# Maximum time to wait for a DNS query to complete
+QUERY_TIMEOUT = 4
+
 #Python 2.x and 3.x compatiablity
 #We need the Queue library for exception handling
 try:
@@ -63,7 +66,7 @@ class resolver:
         self.last_resolver = name_server
         query = dnslib.DNSRecord.question(hostname, query_type.upper().strip())
         try:
-            response_q = query.send(name_server, 53, use_tcp)
+            response_q = query.send(name_server, 53, use_tcp, QUERY_TIMEOUT)
             if response_q:
                 response = dnslib.DNSRecord.parse(response_q)
             else:


### PR DESCRIPTION
Added a timeout to DNS queries. Not having this could make the initial bootstrapping process take a **really** long time. This happens when a significant proportion of the resolvers being used either don't respond or are otherwise broken. The default timeout makes it wait like 30s if I'm not mistaken so coming across 10 of these could make the code spend 5 minutes running with no viable nameservers available to the workers. This is especially problematic when a large number of processes is used.