### PR TITLE
Fix use of incorrect method

### DIFF
--- a/subbrute.py
+++ b/subbrute.py
@@ -351,11 +351,11 @@ class lookup(multiprocessing.Process):
                     added_cname = False
                     #A max 20 lookups
                     cname_host = host
-                    resp = self.resolver.query(cname_host, "A", total_rechecks)
+                    resp = self.check(cname_host, "A", total_rechecks)
                     if not resp:
-                        resp = self.resolver.query(cname_host, "AAAA", total_rechecks)
+                        resp = self.check(cname_host, "AAAA", total_rechecks)
                     if not resp:
-                        resp = self.resolver.query(cname_host, "CNAME", total_rechecks)
+                        resp = self.check(cname_host, "CNAME", total_rechecks)
                     for r in resp:
                         return_name, record_type, record_data = r
                         #if record_type in ["CNAME", "A", "AAAA"]:


### PR DESCRIPTION
When checking `CNAME` records, the code calls:
```python
self.resolver.query(cname_host, "A", total_rechecks)
```

Which results in an integer argument being given for the `name_server` argument in the `resolver.query` method which has the signature:
```python
def query(self, hostname, query_type = 'ANY', name_server = False, use_tcp = False):
```
And causes an error to be raised in `dnslib`:
```
File "dnslib/dns.py", line 375, in send
    sock.sendto(self.pack(),(dest,port))
TypeError: coercing to Unicode: need string or buffer, int found
```

It seems from the call signature intended to be recursive call to the `check` method itself with a preservation of the retry count so that's what I put in.