### PR TITLE
Clean up processes created by main process

### DIFF
--- a/subbrute.py
+++ b/subbrute.py
@@ -727,6 +727,14 @@ def run(target, query_type = "ANY", subdomains = "names.txt", resolve_list = Fal
     except:
         #Windows threading.tread
         verify_nameservers_proc.end()
+    
+    trace("About to kill the reeper process...")
+    reep.terminate()
+    
+    trace("Collecting the work processes...")
+    for w in worker_list:
+        w.join()
+        
     trace("End")
 
 #exit handler for signals.  So ctrl+c will work. 


### PR DESCRIPTION
Currently, the reeper process (which replaces "lazy" workers) and the worker processes themselves are not collected properly before termination which leads to zombies being left over each time the code is run. These changes should fix that. 