### PR TITLE
Fix setup of resolver verification

### DIFF
--- a/subbrute.py
+++ b/subbrute.py
@@ -155,7 +155,7 @@ class verify_nameservers(multiprocessing.Process):
         self.resolver_q = resolver_q
         self.query_type = query_type
         self.resolver_list = resolver_list
-        self.resolver = resolver()
+        self.resolver = resolver([])
         #The domain provided by the user.
         self.target = target
         #Resolvers that will work in a pinch:
@@ -224,7 +224,7 @@ class verify_nameservers(multiprocessing.Process):
         #2)The target maybe using geolocaiton-aware DNS.
         #I have seen a CloudFlare Enterprise customer with these two conditions.
         try:
-            blanktest = self.resolver.query(self.target, self.query_type)
+            blanktest = self.resolver.query(self.target, self.query_type, server)
             if self.query_type == "ANY":
                 #If the type was ANY we should have gotten some records
                 if not len(blanktest) and not self.authoritative:


### PR DESCRIPTION
Previously, the resolver instance used by the process is set up with no arguments to the constructor but since the signature of the constructor is:
```python
def __init__(self, nameservers = ['8.8.8.8','8.8.4.4'])
```

This actually creates a resolver with the Google DNS servers as the nameservers to use. Then, in the blank test on [line 227](https://github.com/TheRook/subbrute/blob/c5b96610129bedcb4c322b8864f67985b3e808f8/subbrute.py#L227), a resolution is made for the blank domain as part of the verification:
```python
blanktest = self.resolver.query(self.target, self.query_type)
```

However, since no nameserver is explicitly specified, the Google DNS servers are actually used again for this. This means the verification process actually hits the Google servers at least once for every server they verify and don't actually verify the behaviour of the server itself. This means that if Google's DNS servers start to throttle you then other nameservers will be flagged as having timed out even though they haven't been touched at all.